### PR TITLE
Fix incorrect IRI escapes

### DIFF
--- a/lib/TermUtil.ts
+++ b/lib/TermUtil.ts
@@ -205,8 +205,10 @@ function escapeStringRDF(stringValue: string): string {
 }
 
 // Characters in literals and IRIs that require escaping
-const escapePattern = /["\\\t\n\r\b\f\u0000-\u0019]|[\uD800-\uDBFF\uDC00-\uDFFF]/ug;
 // Also containing potential surrogate pairs
+/* eslint-disable require-unicode-regexp */ /* eslint-disable unicorn/better-regex */
+const escapePattern = /["\\\t\n\r\b\f\u0000-\u0019]|[\uD800-\uDBFF][\uDC00-\uDFFF]/g;
+/* eslint-enable require-unicode-regexp */ /* eslint-enable unicorn/better-regex */
 const escapes = new Map([
   [ '\\', '\\\\' ],
   [ '"', '\\"' ],

--- a/test/TermUtil-test.ts
+++ b/test/TermUtil-test.ts
@@ -17,6 +17,11 @@ describe('TermUtil', () => {
       expect(TermUtil.termToString(FACTORY.namedNode('http://example.org'))).toEqual('<http://example.org>');
     });
 
+    it('should transform a named node with dashes', async() => {
+      expect(TermUtil.termToString(FACTORY.namedNode('http://this-is-an-example.com')))
+        .toEqual('<http://this-is-an-example.com>');
+    });
+
     it('should transform a blank node', async() => {
       expect(TermUtil.termToString(FACTORY.blankNode('b1'))).toEqual('_:b1');
     });


### PR DESCRIPTION
This should fix issue https://github.com/rubensworks/rdf-string-ttl.js/issues/5.

This is the best I can do for now. Removing the unicode flag again seems to solve it, but I don't know why. I mainly don't know why a `-` is matched by the surrogate pair part of the RegEx: the ranges don't fit.

Because the unicode flag is removed, the linting rules that urge to put it back had to be disabled. The other linting rules wants to simplify the expression, but then it is not longer clear what characters are included.